### PR TITLE
Alteração no pom.xml para resolver conflito de versão da dependencia hibernate-validator 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>7.0.0.Final</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-security -->


### PR DESCRIPTION
Retira a tag version da dependencia hibernate-validator pois ela causa conflito impedindo a validacao dos campos